### PR TITLE
expose internals for secondary tabs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,11 @@ export const Tabs = ({ state: outerState, children }) => {
   )
 }
 
+export const useUnsafeTabState = () => {
+  const [activeIndex, setActive] = useContext(TabsState)
+  return { activeIndex, setActive }
+}
+
 export const useTabState = () => {
   const [activeIndex, setActive] = useContext(TabsState)
   const elements = useContext(Elements)


### PR DESCRIPTION
current API works great for single set of tabs. if you need a secondary set for like mobile, more access is needed to maintain state. with this new exposed API, multiple UIs for the same tabs can be kept in sync.

```jsx
function ButtonTab() {
  const { onClick } = useTabState()

  return <button onClick={onClick}>{children}</button>
}

function ResponsiveTabs() {
  const { activeIndex, setActive } = useUnsafeTabState()

  function handleChange(evt) {
    setActive(evt.target.value)
  }

  return (
    <Tabs>
      {/* Dropdown menu on small screens */}
      <div className="sm:hidden">
        <select
            value={activeIndex}
            onBlur={handleChange}
            onChange={handleChange}
            aria-label="Selected tab"
        >
          <option value="0">1</option>
          <option value="1">1</option>
        </select>
      </div>
      
      {/* Tabs at small breakpoint and up */}
      <div className="hidden sm:block">
        <ButtonTab>1</ButtonTab>
        <ButtonTab>2</ButtonTab>
      </div>
    </Tabs>
  )
}
```