### PR TITLE
fix: remove inconsistencies when using React.StrictMode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,13 +48,13 @@ import React from "react";
 import { Tabs, useTabState, usePanelState } from "@bumaga/tabs";
 
 const Tab = ({ children }) => {
-  const { onClick } = useTabState();
+  const { onClick } = useTabState(children);
 
   return <button onClick={onClick}>{children}</button>;
 };
 
 const Panel = ({ children }) => {
-  const isActive = usePanelState();
+  const isActive = usePanelState(children);
 
   return isActive ? <p>{children}</p> : null;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const Elements = createContext()
 
 export const Tabs = ({ state: outerState, children }) => {
   const innerState = useState(0)
-  const elements = useConstant(() => ({ tabs: 0, panels: 0 }))
+  const elements = useConstant(() => ({ tabs: [], panels: [] }))
   const state = outerState || innerState
 
   return (
@@ -24,15 +24,20 @@ export const Tabs = ({ state: outerState, children }) => {
   )
 }
 
-export const useTabState = () => {
+export const useTabState = (children) => {
   const [activeIndex, setActive] = useContext(TabsState)
   const elements = useContext(Elements)
 
   const tabIndex = useConstant(() => {
-    const currentIndex = elements.tabs
-    elements.tabs += 1
+    const currentIndex = elements.tabs.length
+    const childrenIndex = elements.tabs.indexOf(children)
 
-    return currentIndex
+    const isChildrenUnique = !elements.tabs.includes(children)
+    if (isChildrenUnique) {
+      elements.tabs.push(children)
+    }
+
+    return isChildrenUnique ? currentIndex : childrenIndex
   })
 
   const onClick = useConstant(() => () => setActive(tabIndex))
@@ -48,22 +53,27 @@ export const useTabState = () => {
   return state
 }
 
-export const usePanelState = () => {
+export const usePanelState = (children) => {
   const [activeIndex] = useContext(TabsState)
   const elements = useContext(Elements)
 
   const panelIndex = useConstant(() => {
-    const currentIndex = elements.panels
-    elements.panels += 1
+    const currentIndex = elements.panels.length
+    const childrenIndex = elements.panels.indexOf(children)
 
-    return currentIndex
+    const isChildrenUnique = !elements.panels.includes(children)
+    if (isChildrenUnique) {
+      elements.panels.push(children)
+    }
+
+    return isChildrenUnique ? currentIndex : childrenIndex
   })
 
   return panelIndex === activeIndex
 }
 
 export const Tab = ({ children }) => {
-  const state = useTabState()
+  const state = useTabState(children)
 
   if (typeof children === 'function') {
     return children(state)
@@ -73,7 +83,7 @@ export const Tab = ({ children }) => {
 }
 
 export const Panel = ({ active, children }) => {
-  const isActive = usePanelState()
+  const isActive = usePanelState(children)
 
   return isActive || active ? children : null
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,3 +39,19 @@ test('renders and change tabs', () => {
   expect(container).not.toHaveTextContent('content 1')
   expect(container).toHaveTextContent('content 2')
 })
+
+test('renders and change tabs when using React.StrictMode', () => {
+  const { container, queryByText } = render(
+    <React.StrictMode>
+      <Testing />
+    </React.StrictMode>
+  )
+
+  expect(container).toHaveTextContent('content 1')
+  expect(container).not.toHaveTextContent('content 2')
+
+  fireEvent.click(queryByText('tab 2'))
+
+  expect(container).not.toHaveTextContent('content 1')
+  expect(container).toHaveTextContent('content 2')
+})


### PR DESCRIPTION
This PR aims to fix #219.

To do so a change was done in the way `<Tab>` and `<Panel>` are counted. Previously `<Tab>` and `<Panel>` were counted based on how many times the relative hooks were called, such a usage was a problem when using [`<React.StrictMode>`](https://reactjs.org/docs/strict-mode.html) that duplicates renders during development.

The way we corrected this issue is by caching the children of the `<Tab>` or `<Panel>` components in an array, making sure that only unique children get pushed into the cache. With this we only changed the way the index is calculated.

Fixes #219